### PR TITLE
Adds keyword mappings

### DIFF
--- a/likepython/README
+++ b/likepython/README
@@ -30,9 +30,11 @@ Here's a version that asks you for your name, then says hi. (Note that 'yo' is a
             toootally just exit()
         else:
             um yeah
-            print like "Hi %s, nice to meet you." % name
+            tellem like "Hi %s, nice to meet you." % name
 
-A full list of Like, Python keywords is below (swearing optional):
+Like, Python also adds mappings so you don't have to keep using the same lame keywords. For example, instead of `print`, `tellem` or `holla`, and instead of `exit`ing you can just `fuckit`.
+
+A full list of Like, Python keywords and mappings is below (swearing optional):
 
 Valleygirl:	omg, so, like, totally, right, toootally
 Frat guy:	friggin, fuckin, dude, man, bro, broheim, broseph
@@ -40,7 +42,7 @@ Internets:	lol, rofl, teh, ohai, plz
 Snoop:	yo, homey, homeboy, sup, dog, shit, girl, ma, biatch, ho, shiiit
 Local:	wicked, hella, anyways
 Misc: just, hey, yeah, ok, um, uh, ah, actually, something
-
+Mappings: tellem => print, holla => print, srsly => finally, rockon => continue, an => and, mostdef => assert, fuckit => exit
 
 
 INSTALLATION

--- a/likepython/trunk/likepython
+++ b/likepython/trunk/likepython
@@ -17,12 +17,20 @@ like_python_tokens = ['omg','so','like','totally','right','toootally',
                           'something',
                      ]
 
+like_python_mappings = {'tellem':'print', 'holla':'print', 'srsly':'finally',
+                        'rockon':'continue', 'an':'and', 'mostdef':'assert',
+                        'fuckit':'exit'
+                       }
+
 def handle_input():
   if len(sys.argv) == 2:
     return sys.argv[1]
   else:
     print "Usage: likepython path/to/file.lp"
     exit()
+
+def py_map(token):
+  return token if token not in like_python_mappings else like_python_mappings[token]
 
 def main():
     # Parse input file for tokens
@@ -31,7 +39,7 @@ def main():
     tokens = tokenize.generate_tokens(file.readline)
 
     # Remove likepython tokens, leaving valid python temp file behind.
-    py_tokens = [(type,token) for (type,token, _, _, _) in tokens if token not in like_python_tokens]
+    py_tokens = [(type,py_map(token)) for (type,token, _, _, _) in tokens if token not in like_python_tokens]
     py = tokenize.untokenize(py_tokens)
     output_filename = input_file + ".py"
     output_file = open(output_filename, 'w')

--- a/likepython/trunk/test.lp
+++ b/likepython/trunk/test.lp
@@ -1,12 +1,12 @@
 #!usr/bin/python
 from sys import exit
-  
+
 # Grab the user's name.
 ok so like name = raw_input("yo! what's your name? " ) right
 
 # Make sure they entered something and say hi.
 if name.strip() is actually like "":
-    toootally just exit()
+    toootally just fuckit()
 else:
     um yeah
-    print like "Hi %s, nice to meet you." % name
+    tellem like "Hi %s, nice to meet you." % name


### PR DESCRIPTION
Adds mappings so you don't have to keep using the same lame keywords. For example, instead of `print`, `tellem` or `holla`, and instead of `exit`ing you can just `fuckit`.

Full list of mappings: tellem => print, holla => print, srsly => finally, rockon => continue, an => and, mostdef => assert, fuckit => exit
